### PR TITLE
fixed typo in container name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We offer a pre-built Docker Image for the Infinity Embedding Serverless Worker t
 You can directly use the following docker images and configure them via Environment Variables.
 | CUDA Version | Stable (Latest Release)                 | Development (Latest Commit)             | Note                                                        |
 |--------------|-----------------------------------|-----------------------------------|----------------------------------------------------------------------|
-| 11.8.0       | `runpod/worker-infinity-embedding:stable-cuda111.8.0`        | `runpod/worker-infinity-embedding:dev-cuda11.8.0`   | Available on all RunPod Workers without additional selection needed. |
+| 11.8.0       | `runpod/worker-infinity-embedding:stable-cuda11.8.0`        | `runpod/worker-infinity-embedding:dev-cuda11.8.0`   | Available on all RunPod Workers without additional selection needed. |
 | 12.1.0       | `runpod/worker-infinity-embedding:stable-cuda12.1.0` | `runpod/worker-infinity-embedding:dev-cuda12.1.0` | When creating an Endpoint, select CUDA Version 12.4, 12.3, 12.2 and 12.1 in the filter. About 10% less total available machines than 11.8.0, but higher performance. |
 
 ### 2. Select your models and configure your deployment with Environment Variables


### PR DESCRIPTION
There was a typo in the table in part 1: Select Worker Image Version

I you don't pay attention you might not be able to pull the image