### PR TITLE
Upgrade from EOL CUDA version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG WORKER_CUDA_VERSION=12.1.0
-FROM runpod/base:0.6.2-cuda${WORKER_CUDA_VERSION}
+ARG WORKER_CUDA_VERSION=12.4.1
+FROM runpod/pytorch:2.4.0-py3.11-cuda${WORKER_CUDA_VERSION}-devel-ubuntu22.04
 
 #Reinitialize, as its lost after the FROM command
-ARG WORKER_CUDA_VERSION=12.1.0
+ARG WORKER_CUDA_VERSION=12.4.1
 
 # Python dependencies
 COPY builder/requirements.txt /requirements.txt
@@ -12,7 +12,7 @@ RUN python3.11 -m pip install --upgrade pip && \
 
 RUN pip uninstall torch -y && \
     CUDA_VERSION_SHORT=$(echo ${WORKER_CUDA_VERSION} | cut -d. -f1,2 | tr -d .) && \
-    pip install --pre torch==2.4.0.dev20240518+cu${CUDA_VERSION_SHORT} --index-url https://download.pytorch.org/whl/nightly/cu${CUDA_VERSION_SHORT} --no-cache-dir
+    pip install torch==2.5.1 --index-url https://download.pytorch.org/whl/test/cu${CUDA_VERSION_SHORT} --no-cache-dir
 
 ENV HF_HOME=/runpod-volume
 

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,4 +1,4 @@
 runpod~=1.7.0
-infinity-emb[all,onnxruntime-gpu]==0.0.53
+infinity-emb[all,onnxruntime-gpu,cache,ct2,logging,optimum,server,tensorrt,torch]==0.0.73
 einops # deployment of custom code with nomic
-git+https://github.com/pytorch-labs/float8_experimental.git@f7a920d2c53db8912f2a0c1d9040dbe71a88906d
+git+https://github.com/pytorch-labs/float8_experimental.git


### PR DESCRIPTION
Previously, CUDA 12.1.0 was being used, which is EOL and unsupported as of June 30th, 2023 (https://gitlab.com/nvidia/container-images/cuda/-/commit/d0534bbb1453b6a3a0ed61337125481f2ef6d98a). This commit upgrades to CUDA 12.4.1, the latest version available in runpod's prebuilt Docker images, as well as torch 2.5.1, the latest stable release of PyTorch that supports CUDA 12.4.

A similar fork accomplished something similar [here](https://github.com/BillJones-SectorFlow/worker-infinity-embedding/commit/f7f400bd685cccd68f2b35a19c76e43db0d5bb23).

My docker image is here, and I can confirm it works: https://hub.docker.com/r/noahbpeters1997/worker-infinity-embedding-test/tags